### PR TITLE
Feature #159265221 – Make component re-render on new props

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,25 @@ a set of filtering controls. Filter groups can be displayed either as searchable
 
 The prop `ResultElementClass` must be coupled to the shape of your `element` objects to be shown correctly.
 
+Two more optional props, namely `noResultsMessageFormatter` and `resultsMessageFormatter`, return a string which is
+displayed when there are no results, and as a header on top of the search results, respectively. In many occasions it
+is useful to display such messages using information returned by the server; that’s the reason why both functions take
+the JSON payload as an argument, allowing for some customisation in that regard. For example, if in the case of no
+results the server returns a field `reason` you could have something like this:
+```
+<ReactFacetedSearch
+  ...
+  noResultsMessageFormatter={(data) => `Your search yielded no results: ${data.reason}`}
+```
+
 The sidebar disables/hides options in order to avoid combinations that would produce empty results. However it is not
-100% foolproof since you can arrive at a no results state by unchecking options, but you disabling an already chosen
-facet is bad UX.
+100% foolproof since you can arrive at a no results state by unchecking options, but disabling an already chosen
+facet can potentially lock the user without no apparent reason, resulting in bad UX.
 
 # Try it out
 Just run [webpack-dev-server](https://github.com/webpack/webpack-dev-server):
 ```
-npx webpack-dev-server --mode=development
+npx webpack-dev-server -d
 ```
 
 # Combining with the EBI Visual Framework
@@ -36,7 +47,8 @@ Therefore it’s convenient to add the snippet below to override the styling set
 }
 ```
 At the time of writing this applies to the most recent version (v1.3). Wrapping these styles within the appropriate
-`div` selector is sufficient. See https://github.com/ebi-gene-expression-group/scxa-faceted-search-results/blob/master/html/filter-list.html for a
+`div` selector is sufficient. See
+https://github.com/ebi-gene-expression-group/scxa-faceted-search-results/blob/master/html/filter-list.html for a
 working example.
 
 # A note about building with Webpack
@@ -184,4 +196,5 @@ The component uses `async`/`await` to fetch the JSON payload from the server. Th
 ```
 
 # TODO
-- Refactor `FetchLoader` as a HOC. This makes it highly reusable and will let clients of this component get the results however they prefer.
+- Refactor `FetchLoader` as a HOC. This makes it highly reusable and will let clients of this component get the results
+however they prefer.

--- a/__test__/CalloutAlert.test.js
+++ b/__test__/CalloutAlert.test.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import Enzyme from 'enzyme'
+import renderer from 'react-test-renderer'
+import { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+import fetchMock from 'fetch-mock'
+
+import CalloutAlert from '../src/CalloutAlert'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe(`CalloutAlert`, () => {
+  const props = {
+    error: {
+      description: `A human-readable description of the error, hopefully useful to the user`,
+      name: `Error name`,
+      message: `Error message`
+    }
+  }
+
+  it(`prints all the relevant error information`, () => {
+    const wrapper = shallow(<CalloutAlert {...props} />)
+    expect(wrapper.text()).toMatch(props.error.description)
+    expect(wrapper.text()).toMatch(props.error.name)
+    expect(wrapper.text()).toMatch(props.error.message)
+  })
+
+  it(`matches snapshot`, () => {
+    const tree = renderer.create(<CalloutAlert {...props} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/__test__/FetchLoader.test.js
+++ b/__test__/FetchLoader.test.js
@@ -8,6 +8,7 @@ import { getRandomInt } from './TestUtils'
 
 import FetchLoader from '../src/FetchLoader'
 import CalloutAlert from '../src/CalloutAlert'
+import FacetedSearchContainer from '../src/FacetedSearchContainer'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -85,5 +86,54 @@ describe(`FetchLoader`, () => {
     await wrapper.instance().componentDidUpdate()
     wrapper.update()
     expect(wrapper.find(CalloutAlert)).toHaveLength(0)
+  })
+
+  test(`passes JSON payload to prop resultsMessageFormatter`, async () => {
+    fetchMock.get(`*`, `{"results":[{"element": {"character": "Pickle Rick"}}], "searchPhrase": "best characters"}`)
+    const wrapper =
+      shallow(
+        <FetchLoader
+          {...props}
+          resultsMessageFormatter={(data) => `Results for ${data.searchPhrase}:`} />)
+
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    expect(wrapper.find(FacetedSearchContainer).prop(`resultsMessage`)).toBe(`Results for best characters:`)
+  })
+
+  test(`passes JSON payload to prop noResultsMessageFormatter`, async () => {
+    fetchMock.get(`*`, `{"results":[], "reason": "Rubber baby bubby bunkers!"}`)
+    const wrapper =
+      shallow(
+        <FetchLoader
+          {...props}
+          noResultsMessageFormatter={(data) => `No results: ${data.reason}`} />)
+
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    expect(wrapper.find(`h5`).text()).toBe(`No results: Rubber baby bubby bunkers!`)
+  })
+
+  test(`results message by default is empty`, async () => {
+    fetchMock.get(`*`, `{"results":[{"element": {"character": "Pickle Rick"}}], "searchPhrase": "best characters"}`)
+    const wrapper = shallow(<FetchLoader {...props} />)
+
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    expect(wrapper.find(FacetedSearchContainer).prop(`resultsMessage`)).toBe(``)
+  })
+
+  test(`no results message by default is empty`, async () => {
+    fetchMock.get(`*`, `{"results":[], "reason": "Rubber baby bubby bunkers!"}`)
+    const wrapper = shallow(<FetchLoader {...props} />)
+
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+
+    expect(wrapper.find(`h5`).text()).toBe(``)
+
   })
 })

--- a/__test__/FetchLoader.test.js
+++ b/__test__/FetchLoader.test.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import Enzyme from 'enzyme'
-import {mount} from 'enzyme'
+import { shallow } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-16'
 import fetchMock from 'fetch-mock'
 
-import {getRandomInt} from './TestUtils'
+import { getRandomInt } from './TestUtils'
 
 import FetchLoader from '../src/FetchLoader'
+import CalloutAlert from '../src/CalloutAlert'
 
 Enzyme.configure({ adapter: new Adapter() })
 
@@ -27,42 +28,62 @@ describe(`FetchLoader`, () => {
 
   test(`until the fetch promise is not resolved a loading message is displayed, then goes away`, async () => {
     fetchMock.get(`*`, `{"results":[]}`)
-    const wrapper = mount(<FetchLoader {...props} />)
+    const wrapper = shallow(<FetchLoader {...props} />)
 
     expect(wrapper.find(`#loader`)).toHaveLength(1)
-    expect(wrapper.find(`.callout .alert`)).toHaveLength(0)
+    expect(wrapper.find(CalloutAlert)).toHaveLength(0)
+
     await wrapper.instance().componentDidMount()
     wrapper.update()
+
     expect(wrapper.find(`#loader`)).toHaveLength(0)
-    expect(wrapper.find(`.callout .alert`)).toHaveLength(0)
+    expect(wrapper.find(CalloutAlert)).toHaveLength(0)
   })
 
   test(`renders an error message if request to the server returns 4xx or 5xx`, async () => {
     fetchMock.get(`*`, getRandomHttpErrorCode)
-    const wrapper = mount(<FetchLoader {...props} />)
+    const wrapper = shallow(<FetchLoader {...props} />)
 
     await wrapper.instance().componentDidMount()
     wrapper.update()
-    expect(wrapper.find(`.callout.alert`)).toHaveLength(1)
+    expect(wrapper.find(CalloutAlert)).toHaveLength(1)
   })
 
   test(`renders an error message if the component does not receive JSON`, async () => {
     fetchMock.get(`*`, `Break the cycle, Morty. Rise above. Focus on the science`)
-    const wrapper = mount(<FetchLoader {...props} />)
+    const wrapper = shallow(<FetchLoader {...props} />)
 
     await wrapper.instance().componentDidMount()
     wrapper.update()
-    expect(wrapper.find(`.callout.alert`)).toHaveLength(1)
+    expect(wrapper.find(CalloutAlert)).toHaveLength(1)
   })
 
   test(`renders an error message if the child receives invalid JSON (and the error boundary kicks in)`, async () => {
     fetchMock.get(`*`, `{}`)
-    const wrapper = mount(<FetchLoader {...props} />)
+    const wrapper = shallow(<FetchLoader {...props} />)
 
     const e = new Error(`They’re inside you building a monument to compromise!`)
     wrapper.instance().componentDidCatch(e, `Ruben’s seen some rough years, Morty.`)
     wrapper.update()
-    expect(wrapper.find(`.callout.alert`)).toHaveLength(1)
+    expect(wrapper.find(CalloutAlert)).toHaveLength(1)
   })
 
+  test(`re-fetches on props change and recovers from error if new fetch succeeds`, async () => {
+    fetchMock.get(`/glip/glops`, getRandomHttpErrorCode)
+    const wrapper = shallow(<FetchLoader {...props} />)
+
+    await wrapper.instance().componentDidMount()
+    wrapper.update()
+    expect(wrapper.find(CalloutAlert)).toHaveLength(1)
+
+    fetchMock.get(`/glops/glip`, `{"results":[]}`)
+    wrapper.setProps({
+      host: `glops/`,
+      resource: `glip`
+    })
+
+    await wrapper.instance().componentDidUpdate()
+    wrapper.update()
+    expect(wrapper.find(CalloutAlert)).toHaveLength(0)
+  })
 })

--- a/__test__/__snapshots__/CalloutAlert.test.js.snap
+++ b/__test__/__snapshots__/CalloutAlert.test.js.snap
@@ -1,0 +1,29 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalloutAlert matches snapshot 1`] = `
+<div
+  className="row column"
+>
+  <div
+    className="callout alert small"
+  >
+    <h5>
+      Oops!
+    </h5>
+    <p>
+      A human-readable description of the error, hopefully useful to the user
+      <br />
+      If the error persists, in order to help us debug the issue, please copy the URL and this message and send it to us via 
+      <a
+        href="https://www.ebi.ac.uk/support/gxasc"
+      >
+        the EBI Support & Feedback system
+      </a>
+      :
+    </p>
+    <code>
+      Error name: Error message
+    </code>
+  </div>
+</div>
+`;

--- a/html/fetchLoaderDemo.js
+++ b/html/fetchLoaderDemo.js
@@ -6,8 +6,11 @@ import FetchLoader from '../src/FetchLoader'
 import ExperimentCard from './ExperimentCard'
 
 const render = (options, target) => {
-  ReactDOM.render(<FetchLoader {...options}
-                               ResultElementClass={ExperimentCard}/>, document.getElementById(target))
+  ReactDOM.render(
+    <FetchLoader
+      {...options}
+      ResultElementClass={ExperimentCard} />,
+    document.getElementById(target))
 }
 
 export {render}

--- a/html/full-demo.html
+++ b/html/full-demo.html
@@ -30,9 +30,13 @@
 
 <!-- Set to http://localhost:8080/gxa/ or http://localhost:8080/gxa/sc/ -- Remember the trailing slash! -->
 <script>
+    const symbol = `foobar`;
+
     fetchLoaderDemo.render({
       host: 'http://localhost:8080/gxa/sc/',
-      resource: 'json/search?symbol=BRCA1'
+      resource: 'json/search?symbol=' + symbol,
+      resultsMessageFormatter: function(data) { return symbol + ' ' + data.searchExplanation + ' is expressed in:'; },
+      noResultsMessageFormatter: function(data) { return 'Your search for ' + symbol + ' yielded no results: ' + data.reason; }
     }, 'target');
 </script>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.1.0-beta",
+  "version": "2.2.1-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -732,6 +732,12 @@
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
           "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+          "dev": true
         }
       }
     },
@@ -795,6 +801,14 @@
         "@babel/plugin-transform-react-jsx": "^7.0.0",
         "@babel/plugin-transform-react-jsx-self": "^7.0.0",
         "@babel/plugin-transform-react-jsx-source": "^7.0.0"
+      }
+    },
+    "@babel/runtime": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.1.2.tgz",
+      "integrity": "sha512-Y3SCjmhSupzFB6wcv1KmmFucH6gDVnI30WjOcicV10ju0cZjak3Jcs67YLIXBrmZYw1xCrVeJPbycFwrqNyxpg==",
+      "requires": {
+        "regenerator-runtime": "^0.12.0"
       }
     },
     "@babel/template": {
@@ -917,180 +931,180 @@
       "integrity": "sha512-rLu3wcBWH4P5q1CGoSSH/i9hrXs7SlbRLkoq9IGuoPYNGQvDJ3pt/wmOM+XgYjIDRMVIdkUWt0RsfzF50JfnCw=="
     },
     "@types/node": {
-      "version": "10.12.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.1.tgz",
-      "integrity": "sha512-i1sl+WCX2OCHeUi9oi7PiCNUtYFrpWhpcx878vpeq/tlZTKzcFdHePlyFHVbWqeuKN0SRPl/9ZFDSTsfv9h7VQ==",
+      "version": "10.12.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.2.tgz",
+      "integrity": "sha512-53ElVDSnZeFUUFIYzI8WLQ25IhWzb6vbddNp8UHlXQyU0ET2RhV5zg0NfubzU7iNMh5bBXb0htCzfvrSVNgzaQ==",
       "dev": true
     },
     "@webassemblyjs/ast": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.10.tgz",
-      "integrity": "sha512-wTUeaByYN2EA6qVqhbgavtGc7fLTOx0glG2IBsFlrFG51uXIGlYBTyIZMf4SPLo3v1bgV/7lBN3l7Z0R6Hswew==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.7.11.tgz",
+      "integrity": "sha512-ZEzy4vjvTzScC+SH8RBssQUawpaInUdMTYwYYLh54/s8TuT0gBLuyUnppKsVyZEi876VmmStKsUs28UxPgdvrA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/helper-module-context": "1.7.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-        "@webassemblyjs/wast-parser": "1.7.10"
+        "@webassemblyjs/helper-module-context": "1.7.11",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+        "@webassemblyjs/wast-parser": "1.7.11"
       }
     },
     "@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.10.tgz",
-      "integrity": "sha512-gMsGbI6I3p/P1xL2UxqhNh1ga2HCsx5VBB2i5VvJFAaqAjd2PBTRULc3BpTydabUQEGlaZCzEUQhLoLG7TvEYQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.7.11.tgz",
+      "integrity": "sha512-zY8dSNyYcgzNRNT666/zOoAyImshm3ycKdoLsyDw/Bwo6+/uktb7p4xyApuef1dwEBo/U/SYQzbGBvV+nru2Xg==",
       "dev": true
     },
     "@webassemblyjs/helper-api-error": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.10.tgz",
-      "integrity": "sha512-DoYRlPWtuw3yd5BOr9XhtrmB6X1enYF0/54yNvQWGXZEPDF5PJVNI7zQ7gkcKfTESzp8bIBWailaFXEK/jjCsw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.7.11.tgz",
+      "integrity": "sha512-7r1qXLmiglC+wPNkGuXCvkmalyEstKVwcueZRP2GNC2PAvxbLYwLLPr14rcdJaE4UtHxQKfFkuDFuv91ipqvXg==",
       "dev": true
     },
     "@webassemblyjs/helper-buffer": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.10.tgz",
-      "integrity": "sha512-+RMU3dt/dPh4EpVX4u5jxsOlw22tp3zjqE0m3ftU2tsYxnPULb4cyHlgaNd2KoWuwasCQqn8Mhr+TTdbtj3LlA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.7.11.tgz",
+      "integrity": "sha512-MynuervdylPPh3ix+mKZloTcL06P8tenNH3sx6s0qE8SLR6DdwnfgA7Hc9NSYeob2jrW5Vql6GVlsQzKQCa13w==",
       "dev": true
     },
     "@webassemblyjs/helper-code-frame": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.10.tgz",
-      "integrity": "sha512-UiytbpKAULOEab2hUZK2ywXen4gWJVrgxtwY3Kn+eZaaSWaRM8z/7dAXRSoamhKFiBh1uaqxzE/XD9BLlug3gw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.7.11.tgz",
+      "integrity": "sha512-T8ESC9KMXFTXA5urJcyor5cn6qWeZ4/zLPyWeEXZ03hj/x9weSokGNkVCdnhSabKGYWxElSdgJ+sFa9G/RdHNw==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/wast-printer": "1.7.10"
+        "@webassemblyjs/wast-printer": "1.7.11"
       }
     },
     "@webassemblyjs/helper-fsm": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.10.tgz",
-      "integrity": "sha512-w2vDtUK9xeSRtt5+RnnlRCI7wHEvLjF0XdnxJpgx+LJOvklTZPqWkuy/NhwHSLP19sm9H8dWxKeReMR7sCkGZA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.7.11.tgz",
+      "integrity": "sha512-nsAQWNP1+8Z6tkzdYlXT0kxfa2Z1tRTARd8wYnc/e3Zv3VydVVnaeePgqUzFrpkGUyhUUxOl5ML7f1NuT+gC0A==",
       "dev": true
     },
     "@webassemblyjs/helper-module-context": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.10.tgz",
-      "integrity": "sha512-yE5x/LzZ3XdPdREmJijxzfrf+BDRewvO0zl8kvORgSWmxpRrkqY39KZSq6TSgIWBxkK4SrzlS3BsMCv2s1FpsQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.7.11.tgz",
+      "integrity": "sha512-JxfD5DX8Ygq4PvXDucq0M+sbUFA7BJAv/GGl9ITovqE+idGX+J3QSzJYz+LwQmL7fC3Rs+utvWoJxDb6pmC0qg==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.10.tgz",
-      "integrity": "sha512-u5qy4SJ/OrxKxZqJ9N3qH4ZQgHaAzsopsYwLvoWJY6Q33r8PhT3VPyNMaJ7ZFoqzBnZlCcS/0f4Sp8WBxylXfg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.7.11.tgz",
+      "integrity": "sha512-cMXeVS9rhoXsI9LLL4tJxBgVD/KMOKXuFqYb5oCJ/opScWpkCMEz9EJtkonaNcnLv2R3K5jIeS4TRj/drde1JQ==",
       "dev": true
     },
     "@webassemblyjs/helper-wasm-section": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.10.tgz",
-      "integrity": "sha512-Ecvww6sCkcjatcyctUrn22neSJHLN/TTzolMGG/N7S9rpbsTZ8c6Bl98GpSpV77EvzNijiNRHBG0+JO99qKz6g==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.7.11.tgz",
+      "integrity": "sha512-8ZRY5iZbZdtNFE5UFunB8mmBEAbSI3guwbrsCl4fWdfRiAcvqQpeqd5KHhSWLL5wuxo53zcaGZDBU64qgn4I4Q==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-buffer": "1.7.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-        "@webassemblyjs/wasm-gen": "1.7.10"
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-buffer": "1.7.11",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+        "@webassemblyjs/wasm-gen": "1.7.11"
       }
     },
     "@webassemblyjs/ieee754": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.10.tgz",
-      "integrity": "sha512-HRcWcY+YWt4+s/CvQn+vnSPfRaD4KkuzQFt5MNaELXXHSjelHlSEA8ZcqT69q0GTIuLWZ6JaoKar4yWHVpZHsQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.7.11.tgz",
+      "integrity": "sha512-Mmqx/cS68K1tSrvRLtaV/Lp3NZWzXtOHUW2IvDvl2sihAwJh4ACE0eL6A8FvMyDG9abes3saB6dMimLOs+HMoQ==",
       "dev": true,
       "requires": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "@webassemblyjs/leb128": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.10.tgz",
-      "integrity": "sha512-og8MciYlA8hvzCLR71hCuZKPbVBfLQeHv7ImKZ4nlyxrYbG7uJHYtHiHu6OV9SqrGuD03H/HtXC4Bgdjfm9FHw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.7.11.tgz",
+      "integrity": "sha512-vuGmgZjjp3zjcerQg+JA+tGOncOnJLWVkt8Aze5eWQLwTQGNgVLcyOTqgSCxWTR4J42ijHbBxnuRaL1Rv7XMdw==",
       "dev": true,
       "requires": {
         "@xtuc/long": "4.2.1"
       }
     },
     "@webassemblyjs/utf8": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.10.tgz",
-      "integrity": "sha512-Ng6Pxv6siyZp635xCSnH3mKmIFgqWPCcGdoo0GBYgyGdxu7cUj4agV7Uu1a8REP66UYUFXJLudeGgd4RvuJAnQ==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.7.11.tgz",
+      "integrity": "sha512-C6GFkc7aErQIAH+BMrIdVSmW+6HSe20wg57HEC1uqJP8E/xpMjXqQUxkQw07MhNDSDcGpxI9G5JSNOQCqJk4sA==",
       "dev": true
     },
     "@webassemblyjs/wasm-edit": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.10.tgz",
-      "integrity": "sha512-e9RZFQlb+ZuYcKRcW9yl+mqX/Ycj9+3/+ppDI8nEE/NCY6FoK8f3dKBcfubYV/HZn44b+ND4hjh+4BYBt+sDnA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.7.11.tgz",
+      "integrity": "sha512-FUd97guNGsCZQgeTPKdgxJhBXkUbMTY6hFPf2Y4OedXd48H97J+sOY2Ltaq6WGVpIH8o/TGOVNiVz/SbpEMJGg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-buffer": "1.7.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-        "@webassemblyjs/helper-wasm-section": "1.7.10",
-        "@webassemblyjs/wasm-gen": "1.7.10",
-        "@webassemblyjs/wasm-opt": "1.7.10",
-        "@webassemblyjs/wasm-parser": "1.7.10",
-        "@webassemblyjs/wast-printer": "1.7.10"
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-buffer": "1.7.11",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+        "@webassemblyjs/helper-wasm-section": "1.7.11",
+        "@webassemblyjs/wasm-gen": "1.7.11",
+        "@webassemblyjs/wasm-opt": "1.7.11",
+        "@webassemblyjs/wasm-parser": "1.7.11",
+        "@webassemblyjs/wast-printer": "1.7.11"
       }
     },
     "@webassemblyjs/wasm-gen": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.10.tgz",
-      "integrity": "sha512-M0lb6cO2Y0PzDye/L39PqwV+jvO+2YxEG5ax+7dgq7EwXdAlpOMx1jxyXJTScQoeTpzOPIb+fLgX/IkLF8h2yw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.7.11.tgz",
+      "integrity": "sha512-U/KDYp7fgAZX5KPfq4NOupK/BmhDc5Kjy2GIqstMhvvdJRcER/kUsMThpWeRP8BMn4LXaKhSTggIJPOeYHwISA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-        "@webassemblyjs/ieee754": "1.7.10",
-        "@webassemblyjs/leb128": "1.7.10",
-        "@webassemblyjs/utf8": "1.7.10"
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+        "@webassemblyjs/ieee754": "1.7.11",
+        "@webassemblyjs/leb128": "1.7.11",
+        "@webassemblyjs/utf8": "1.7.11"
       }
     },
     "@webassemblyjs/wasm-opt": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.10.tgz",
-      "integrity": "sha512-R66IHGCdicgF5ZliN10yn5HaC7vwYAqrSVJGjtJJQp5+QNPBye6heWdVH/at40uh0uoaDN/UVUfXK0gvuUqtVg==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.7.11.tgz",
+      "integrity": "sha512-XynkOwQyiRidh0GLua7SkeHvAPXQV/RxsUeERILmAInZegApOUAIJfRuPYe2F7RcjOC9tW3Cb9juPvAC/sCqvg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-buffer": "1.7.10",
-        "@webassemblyjs/wasm-gen": "1.7.10",
-        "@webassemblyjs/wasm-parser": "1.7.10"
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-buffer": "1.7.11",
+        "@webassemblyjs/wasm-gen": "1.7.11",
+        "@webassemblyjs/wasm-parser": "1.7.11"
       }
     },
     "@webassemblyjs/wasm-parser": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.10.tgz",
-      "integrity": "sha512-AEv8mkXVK63n/iDR3T693EzoGPnNAwKwT3iHmKJNBrrALAhhEjuPzo/lTE4U7LquEwyvg5nneSNdTdgrBaGJcA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.7.11.tgz",
+      "integrity": "sha512-6lmXRTrrZjYD8Ng8xRyvyXQJYUQKYSXhJqXOBLw24rdiXsHAOlvw5PhesjdcaMadU/pyPQOJ5dHreMjBxwnQKg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-api-error": "1.7.10",
-        "@webassemblyjs/helper-wasm-bytecode": "1.7.10",
-        "@webassemblyjs/ieee754": "1.7.10",
-        "@webassemblyjs/leb128": "1.7.10",
-        "@webassemblyjs/utf8": "1.7.10"
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-api-error": "1.7.11",
+        "@webassemblyjs/helper-wasm-bytecode": "1.7.11",
+        "@webassemblyjs/ieee754": "1.7.11",
+        "@webassemblyjs/leb128": "1.7.11",
+        "@webassemblyjs/utf8": "1.7.11"
       }
     },
     "@webassemblyjs/wast-parser": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.10.tgz",
-      "integrity": "sha512-YTPEtOBljkCL0VjDp4sHe22dAYSm3ZwdJ9+2NTGdtC7ayNvuip1wAhaAS8Zt9Q6SW9E5Jf5PX7YE3XWlrzR9cw==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.7.11.tgz",
+      "integrity": "sha512-lEyVCg2np15tS+dm7+JJTNhNWq9yTZvi3qEhAIIOaofcYlUp0UR5/tVqOwa/gXYr3gjwSZqw+/lS9dscyLelbQ==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/floating-point-hex-parser": "1.7.10",
-        "@webassemblyjs/helper-api-error": "1.7.10",
-        "@webassemblyjs/helper-code-frame": "1.7.10",
-        "@webassemblyjs/helper-fsm": "1.7.10",
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/floating-point-hex-parser": "1.7.11",
+        "@webassemblyjs/helper-api-error": "1.7.11",
+        "@webassemblyjs/helper-code-frame": "1.7.11",
+        "@webassemblyjs/helper-fsm": "1.7.11",
         "@xtuc/long": "4.2.1"
       }
     },
     "@webassemblyjs/wast-printer": {
-      "version": "1.7.10",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.10.tgz",
-      "integrity": "sha512-mJ3QKWtCchL1vhU/kZlJnLPuQZnlDOdZsyP0bbLWPGdYsQDnSBvyTLhzwBA3QAMlzEL9V4JHygEmK6/OTEyytA==",
+      "version": "1.7.11",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.7.11.tgz",
+      "integrity": "sha512-m5vkAsuJ32QpkdkDOUPGSltrg8Cuk3KBx4YrmAGQwCZPRdUHXxG4phIOuuycLemHFr74sWL9Wthqss4fzdzSwg==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/wast-parser": "1.7.10",
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/wast-parser": "1.7.11",
         "@xtuc/long": "4.2.1"
       }
     },
@@ -1128,9 +1142,9 @@
       }
     },
     "acorn": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.2.tgz",
-      "integrity": "sha512-GXmKIvbrN3TV7aVqAzVFaMW8F8wzVX7voEBRO3bDA64+EX37YSayggRJP5Xig6HYHBkWKpFg9W5gg6orklubhg==",
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.0.4.tgz",
+      "integrity": "sha512-VY4i5EKSKkofY2I+6QLTbTTN/UvEQPCo6eiwzzSaSWfpaDhOmStMCMod6wmuPciNq+XS0faCglFu2lHZpdHUtg==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -1173,9 +1187,9 @@
       "dev": true
     },
     "ajv": {
-      "version": "6.5.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
-      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
+      "version": "6.5.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.5.tgz",
+      "integrity": "sha512-7q7gtRQDJSyuEHjuVgHoUa2VuemFiCMrfQc9Tc08XTAc4Zj/5U1buQJ0HU6i7fKjXU09SVgSmxa4sLvuvS8Iyg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1204,7 +1218,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1388,7 +1402,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -1746,6 +1760,12 @@
           "version": "2.5.7",
           "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
           "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
+          "dev": true
+        },
+        "regenerator-runtime": {
+          "version": "0.11.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
           "dev": true
         }
       }
@@ -2177,7 +2197,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -2243,9 +2263,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000903",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000903.tgz",
-      "integrity": "sha512-T1XVJEpGCoaq7MDw7/6hCdYUukmSaS+1l/OQJkLtw7Cr2+/+d67tNGKEbyiqf7Ck8x6EhNFUxjYFXXka0N/w5g==",
+      "version": "1.0.30000906",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000906.tgz",
+      "integrity": "sha512-ME7JFX6h0402om/nC/8Lw+q23QvPe2ust9U0ntLmkX9F2zaGwq47fZkjlyHKirFBuq1EM+T/LXBcDdW4bvkCTA==",
       "dev": true
     },
     "capture-exit": {
@@ -3088,9 +3108,12 @@
       }
     },
     "dom-helpers": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
+      "requires": {
+        "@babel/runtime": "^7.1.2"
+      }
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -3179,9 +3202,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.82",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.82.tgz",
-      "integrity": "sha512-NI4nB2IWGcU4JVT1AE8kBb/dFor4zjLHMLsOROPahppeHrR0FG5uslxMmkp/thO1MvPjM2xhlKoY29/I60s0ew==",
+      "version": "1.3.83",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.83.tgz",
+      "integrity": "sha512-DqJoDarxq50dcHsOOlMLNoy+qQitlMNbYb6wwbE0oUw2veHdRkpNrhmngiUYKMErdJ8SJ48rpJsZTQgy5SoEAA==",
       "dev": true
     },
     "elliptic": {
@@ -4105,9 +4128,9 @@
       }
     },
     "fetch-mock": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.2.2.tgz",
-      "integrity": "sha512-02+L/NR/1+Ey+Hh05f1E8dGjFJGNYlkOq1kvtGjxcVD2/wFBSXFNiG8ecxKWNsREzBI4PECR04Raz0cyLvndKQ==",
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-7.2.5.tgz",
+      "integrity": "sha512-ZdlNxw2xFE2VuGikqWYBcshbfMtWM0k7zWevYgjrFuTiJ1+S7+xjRMxDG1cy45xkpEcqzZAAeqL+uDL5qLZV7g==",
       "dev": true,
       "requires": {
         "babel-polyfill": "^6.26.0",
@@ -5026,9 +5049,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
     "growl": {
@@ -7691,9 +7714,9 @@
       }
     },
     "node-releases": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.2.tgz",
-      "integrity": "sha512-zP8Asfg13lG9KDAW85rylSxXBYvaSdtjMIYKHUk8c1fM8drmFwRqbSYKYD+UlNVPUvrceSvgLUKHMOWR5jPWQg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.3.tgz",
+      "integrity": "sha512-ZaZWMsbuDcetpHmYeKWPO6e63pSXLb50M7lJgCbcM2nC/nQC3daNifmtp5a2kp7EWwYfhuvH6zLPWkrF8IiDdw==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -8497,9 +8520,9 @@
       "dev": true
     },
     "raf": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.0.tgz",
-      "integrity": "sha512-pDP/NMRAXoTfrhCfyfSEwJAKLaxBU9eApMeBPB1TkDouZmvPerIClV8lTAd+uF8ZiTaVl69e1FCxQrAd/VTjGw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "requires": {
         "performance-now": "^2.1.0"
       }
@@ -8757,10 +8780,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+      "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
     },
     "regenerator-transform": {
       "version": "0.13.3",
@@ -9536,9 +9558,9 @@
       }
     },
     "spdy-transport": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.0.tgz",
-      "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.1.1.tgz",
+      "integrity": "sha512-q7D8c148escoB3Z7ySCASadkegMmUZW8Wb/Q1u0/XBgDKMO880rLQDj8Twiew/tYi7ghemKUi/whSYOwE17f5Q==",
       "dev": true,
       "requires": {
         "debug": "^2.6.8",
@@ -9953,12 +9975,12 @@
       "dev": true
     },
     "through2": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
-      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.4.tgz",
+      "integrity": "sha512-q030OX7royN1Bo549nYMOpKwiGJIzUppv10IgB6ALN6DiJ/XgsRIehiz18x5RWCA3+s4G6ovKqtzgU+pYhjvvg==",
       "dev": true,
       "requires": {
-        "readable-stream": "^2.1.5",
+        "readable-stream": "2 || 3",
         "xtend": "~4.0.1"
       }
     },
@@ -10388,9 +10410,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
-      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
+      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
       "dev": true,
       "requires": {
         "querystringify": "^2.0.0",
@@ -10545,15 +10567,15 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.23.1.tgz",
-      "integrity": "sha512-iE5Cu4rGEDk7ONRjisTOjVHv3dDtcFfwitSxT7evtYj/rANJpt1OuC/Kozh1pBa99AUBr1L/LsaNB+D9Xz3CEg==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
+      "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
       "dev": true,
       "requires": {
-        "@webassemblyjs/ast": "1.7.10",
-        "@webassemblyjs/helper-module-context": "1.7.10",
-        "@webassemblyjs/wasm-edit": "1.7.10",
-        "@webassemblyjs/wasm-parser": "1.7.10",
+        "@webassemblyjs/ast": "1.7.11",
+        "@webassemblyjs/helper-module-context": "1.7.11",
+        "@webassemblyjs/wasm-edit": "1.7.11",
+        "@webassemblyjs/wasm-parser": "1.7.11",
         "acorn": "^5.6.2",
         "acorn-dynamic-import": "^3.0.0",
         "ajv": "^6.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.0.3",
+  "version": "2.1.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.1.0-beta",
+  "version": "2.2.1-beta",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {
@@ -58,11 +58,11 @@
     "eslint": "^5.8.0",
     "eslint-config-gene-expression": "^0.4.2",
     "fetch-mock": "^7.2.2",
+    "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
     "react-test-renderer": "^16.6.0",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",
-    "webpack-dev-server": "^3.1.10",
-    "identity-obj-proxy": "^3.0.0"
+    "webpack-dev-server": "^3.1.10"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.0.3",
+  "version": "2.1.0-beta",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {

--- a/src/CalloutAlert.js
+++ b/src/CalloutAlert.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const CalloutAlert = ({error}) =>
+  <div className={`row column`}>
+    <div className={`callout alert small`}>
+      <h5>Oops!</h5>
+      <p>
+        {error.description}<br/>
+        If the error persists, in order to help us debug the issue, please copy the URL and this message and
+        send it to us via <a href={`https://www.ebi.ac.uk/support/gxasc`}>the EBI Support & Feedback system</a>:
+      </p>
+      <code>{`${error.name}: ${error.message}`}</code>
+    </div>
+  </div>
+
+CalloutAlert.propTypes = {
+  error: PropTypes.shape({
+    description: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    message: PropTypes.string.isRequired
+  })
+}
+
+export default CalloutAlert

--- a/src/FetchLoader.js
+++ b/src/FetchLoader.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import URI from 'urijs'
 
+import CalloutAlert from './CalloutAlert'
 import FacetedSearchContainer from './FacetedSearchContainer'
 
 const _fetch = async (host, resource) => {
@@ -12,27 +13,6 @@ const _fetch = async (host, resource) => {
     return await response.json()
   }
   throw new Error(`${url} => ${response.status}`)
-}
-
-const CalloutAlert = ({error}) =>
-  <div className={`row column`}>
-    <div className={`callout alert small`}>
-      <h5>Oops!</h5>
-      <p>
-        {error.description}<br/>
-        If the error persists, in order to help us debug the issue, please copy the URL and this message and
-        send it to us via <a href={`https://www.ebi.ac.uk/support/gxasc`}>the EBI Support & Feedback system</a>:
-      </p>
-      <code>{`${error.name}: ${error.message}`}</code>
-    </div>
-  </div>
-
-CalloutAlert.propTypes = {
-  error: PropTypes.shape({
-    description: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired,
-    message: PropTypes.string.isRequired
-  })
 }
 
 class FetchLoader extends React.Component {

--- a/src/FetchLoader.js
+++ b/src/FetchLoader.js
@@ -34,24 +34,27 @@ class FetchLoader extends React.Component {
   }
 
   render() {
-    const {ResultElementClass, noResultsMessage, resultsMessage} = this.props
-    const {data, loading, error} = this.state
+    const { ResultElementClass, noResultsMessageFormatter, resultsMessageFormatter } = this.props
+    const { data, loading, error } = this.state
 
     return(
       error ?
         <CalloutAlert error={error} /> :
       loading ?
-        <div id={`loader`} className={`row column`}>
-          <p>Loading, please wait...</p>
+        <div id={`loader`} className={`row expanded`}>
+          <div className={`small-12 columns`}>
+            <h5>Loading, please wait...</h5>
+          </div>
         </div> :
         data.results && data.results.length > 0 ?
           <FacetedSearchContainer
             {...data}
             ResultElementClass={ResultElementClass}
-            resultsMessage={resultsMessage}/> :
-          <div className={`row column`}>
-            <p>{noResultsMessage}</p>
-            { data.reason && <p>{data.reason}</p> }
+            resultsMessage={resultsMessageFormatter(data)}/> :
+          <div className={`row expanded`}>
+            <div className={`small-12 columns`}>
+              <h5>{noResultsMessageFormatter(data)}</h5>
+            </div>
           </div>
     )
   }
@@ -107,8 +110,13 @@ FetchLoader.propTypes = {
   host: PropTypes.string.isRequired,
   resource: PropTypes.string.isRequired,
   ResultElementClass: PropTypes.func.isRequired,
-  noResultsMessage: PropTypes.string,
-  resultsMessage: PropTypes.string
+  noResultsMessageFormatter: PropTypes.func,
+  resultsMessageFormatter: PropTypes.func
+}
+
+FetchLoader.defaultProps = {
+  noResultsMessageFormatter: () => ``,
+  resultsMessageFormatter: () => ``
 }
 
 export default FetchLoader


### PR DESCRIPTION
The `FetchLoader` component pulled data initially on `componentDidMount`, so it was ill-suited to be part of a SPA. With this new feature it will pull new data when we do `history.push` in the `<Route>` where this component is wrapped.