### PR TITLE
Feature #162115224 – Improve tooltips with React Tooltip

### DIFF
--- a/__test__/CheckboxFacetGroup.test.js
+++ b/__test__/CheckboxFacetGroup.test.js
@@ -44,7 +44,7 @@ describe(`CheckboxFacetGroup`, () => {
     const randomCheckboxFacetGroupDescription = descriptions[getRandomInt(0, descriptions.length)]
 
     const wrapper = mount(<CheckboxFacetGroup {...propsWithTooltip} />)
-    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tooltip`))
+    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tip`))
   })
 
   test(`doesn’t display tooltip if not present`, () => {

--- a/__test__/FilterSidebar.test.js
+++ b/__test__/FilterSidebar.test.js
@@ -49,7 +49,7 @@ describe(`FilterSidebar`, () => {
     const groups = [...new Set(uniqueFacets.map((facet) => facet.group))]
     const randomCheckboxFacetGroup = groups[getRandomInt(0, groups.length)]
     const wrapper = mount(<FilterSidebar {...props} checkboxFacetGroups={[randomCheckboxFacetGroup]} />)
-    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tooltip`))
+    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tip`))
   })
 
   test(`checks tooltip does not exist when no tooltip text in payload`, () => {

--- a/__test__/MultiselectDropdownFacetGroup.test.js
+++ b/__test__/MultiselectDropdownFacetGroup.test.js
@@ -44,7 +44,7 @@ describe(`MultiselectDropdownFacetGroup`, () => {
     const randomMultiselectFacetGroupDescription = descriptions[getRandomInt(0, descriptions.length)]
 
     const wrapper = mount(<MultiselectDropdownFacetGroup {...propsWithTooltip} />)
-    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tooltip`))
+    expect(wrapper.find(`sup`).first().html()).toEqual(expect.stringMatching(`data-tip`))
   })
 
   test(`doesn’t display tooltip if not present`, () => {

--- a/__test__/TooltipIcon.test.js
+++ b/__test__/TooltipIcon.test.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import randomWords from 'random-words'
+import renderer from 'react-test-renderer'
+import Enzyme from 'enzyme'
+import { shallow } from 'enzyme'
+import Adapter from 'enzyme-adapter-react-16'
+
+import TooltipIcon from '../src/facetgroups/TooltipIcon'
+
+Enzyme.configure({ adapter: new Adapter() })
+
+describe(`TooltipIcon`, () => {
+  test(`breaks very long tooltip texts`, () => {
+    const longText = randomWords(100).join(` `)
+    const wrapper = shallow(<TooltipIcon tooltipText={longText} />)
+    expect(wrapper.find(`span`).prop(`data-tip`).split(`<br>`)).toHaveLength(Math.floor(longText.length / 40))
+  })
+
+  test(`matches snapshot`, () => {
+    const longText = `The blowfish puffs himself up four, five times larger than normal and why? Why does he do that? So that it makes him intimidating, that's why. Intimidating! So that the other, scarier fish are scared off. And that's you! You are a blowfish. You see it's just all an illusion. You see it's... it's nothing but air. Now... who messes with the blowfish, Jesse? You're damn right. You are a blowfish. Say it again. Say it like you mean it. You're a BLOWFISH!`
+    const tree = renderer.create(<TooltipIcon tooltipText={longText} />).toJSON()
+    expect(tree).toMatchSnapshot()
+  })
+})

--- a/__test__/TooltipIcon.test.js
+++ b/__test__/TooltipIcon.test.js
@@ -13,7 +13,8 @@ describe(`TooltipIcon`, () => {
   test(`breaks very long tooltip texts`, () => {
     const longText = randomWords(100).join(` `)
     const wrapper = shallow(<TooltipIcon tooltipText={longText} />)
-    expect(wrapper.find(`span`).prop(`data-tip`).split(`<br>`)).toHaveLength(Math.floor(longText.length / 40) - 1)
+    expect(wrapper.find(`span`).prop(`data-tip`).split(`<br>`).length)
+      .toBeGreaterThanOrEqual(Math.floor((longText.length / 40) - 1))
   })
 
   test(`matches snapshot`, () => {

--- a/__test__/TooltipIcon.test.js
+++ b/__test__/TooltipIcon.test.js
@@ -13,7 +13,7 @@ describe(`TooltipIcon`, () => {
   test(`breaks very long tooltip texts`, () => {
     const longText = randomWords(100).join(` `)
     const wrapper = shallow(<TooltipIcon tooltipText={longText} />)
-    expect(wrapper.find(`span`).prop(`data-tip`).split(`<br>`)).toHaveLength(Math.floor(longText.length / 40))
+    expect(wrapper.find(`span`).prop(`data-tip`).split(`<br>`)).toHaveLength(Math.floor(longText.length / 40) - 1)
   })
 
   test(`matches snapshot`, () => {

--- a/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
@@ -10,11 +10,12 @@ exports[`CheckboxFacetGroup matches snapshot 1`] = `
        
       <span
         className="icon icon-generic"
-        data-icon="?"
-        data-tip="Planets where events in this episode take place"
+        data-icon="i"
+        data-tip="Planets where events in this episode take<br>place"
         style={
           Object {
             "color": "lightgrey",
+            "fontSize": "smaller",
           }
         }
       />

--- a/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
@@ -6,22 +6,14 @@ exports[`CheckboxFacetGroup matches snapshot 1`] = `
 >
   <h4>
     Planet
-    <span>
-      <sup
-        aria-haspopup="true"
-        className="has-tip tip-right"
-        data-tooltip={true}
-        style={
-          Object {
-            "background": "white",
-            "border": "none",
-          }
-        }
-        title="Planets where events in this episode take place"
-      >
-        ?
-      </sup>
-    </span>
+    <sup>
+       
+      <span
+        className="icon icon-generic"
+        data-icon="?"
+        data-tip="Planets where events in this episode take place"
+      />
+    </sup>
   </h4>
   <div>
     <input

--- a/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
@@ -10,8 +10,9 @@ exports[`CheckboxFacetGroup matches snapshot 1`] = `
        
       <span
         className="icon icon-generic"
+        data-html={true}
         data-icon="i"
-        data-tip="Planets where events in this episode take<br>place"
+        data-tip="<span>Planets where events in this episode take<br>place</span>"
         style={
           Object {
             "color": "lightgrey",

--- a/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/CheckboxFacetGroup.test.js.snap
@@ -12,6 +12,11 @@ exports[`CheckboxFacetGroup matches snapshot 1`] = `
         className="icon icon-generic"
         data-icon="?"
         data-tip="Planets where events in this episode take place"
+        style={
+          Object {
+            "color": "lightgrey",
+          }
+        }
       />
     </sup>
   </h4>

--- a/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
+++ b/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
@@ -61,22 +61,14 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
     >
       <h4>
         Guest character
-        <span>
-          <sup
-            aria-haspopup="true"
-            className="has-tip tip-right"
-            data-tooltip={true}
-            style={
-              Object {
-                "background": "white",
-                "border": "none",
-              }
-            }
-            title="Guest characters that tag along for the adventures in this episodes"
-          >
-            ?
-          </sup>
-        </span>
+        <sup>
+           
+          <span
+            className="icon icon-generic"
+            data-icon="?"
+            data-tip="Guest characters that tag along for the adventures in this episodes"
+          />
+        </sup>
       </h4>
       <div
         className="css-10nd86i"
@@ -168,22 +160,14 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
     >
       <h4>
         Planet
-        <span>
-          <sup
-            aria-haspopup="true"
-            className="has-tip tip-right"
-            data-tooltip={true}
-            style={
-              Object {
-                "background": "white",
-                "border": "none",
-              }
-            }
-            title="Planets where events in this episode take place"
-          >
-            ?
-          </sup>
-        </span>
+        <sup>
+           
+          <span
+            className="icon icon-generic"
+            data-icon="?"
+            data-tip="Planets where events in this episode take place"
+          />
+        </sup>
       </h4>
       <div
         className="css-10nd86i"
@@ -315,5 +299,9 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
       </div>
     </div>
   </div>
+  <div
+    className="__react_component_tooltip place-top type-dark "
+    data-id="tooltip"
+  />
 </div>
 `;

--- a/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
+++ b/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
@@ -65,11 +65,12 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
            
           <span
             className="icon icon-generic"
-            data-icon="?"
-            data-tip="Guest characters that tag along for the adventures in this episodes"
+            data-icon="i"
+            data-tip="Guest characters that tag along for the<br>adventures in this episodes"
             style={
               Object {
                 "color": "lightgrey",
+                "fontSize": "smaller",
               }
             }
           />
@@ -169,11 +170,12 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
            
           <span
             className="icon icon-generic"
-            data-icon="?"
-            data-tip="Planets where events in this episode take place"
+            data-icon="i"
+            data-tip="Planets where events in this episode take<br>place"
             style={
               Object {
                 "color": "lightgrey",
+                "fontSize": "smaller",
               }
             }
           />

--- a/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
+++ b/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
@@ -67,6 +67,11 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
             className="icon icon-generic"
             data-icon="?"
             data-tip="Guest characters that tag along for the adventures in this episodes"
+            style={
+              Object {
+                "color": "lightgrey",
+              }
+            }
           />
         </sup>
       </h4>
@@ -166,6 +171,11 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
             className="icon icon-generic"
             data-icon="?"
             data-tip="Planets where events in this episode take place"
+            style={
+              Object {
+                "color": "lightgrey",
+              }
+            }
           />
         </sup>
       </h4>

--- a/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
+++ b/__test__/__snapshots__/FacetedSearchContainer.test.js.snap
@@ -65,8 +65,9 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
            
           <span
             className="icon icon-generic"
+            data-html={true}
             data-icon="i"
-            data-tip="Guest characters that tag along for the<br>adventures in this episodes"
+            data-tip="<span>Guest characters that tag along for the<br>adventures in this episodes</span>"
             style={
               Object {
                 "color": "lightgrey",
@@ -170,8 +171,9 @@ exports[`FacetedSearchContainer matches snapshot 1`] = `
            
           <span
             className="icon icon-generic"
+            data-html={true}
             data-icon="i"
-            data-tip="Planets where events in this episode take<br>place"
+            data-tip="<span>Planets where events in this episode take<br>place</span>"
             style={
               Object {
                 "color": "lightgrey",

--- a/__test__/__snapshots__/FilterSidebar.test.js.snap
+++ b/__test__/__snapshots__/FilterSidebar.test.js.snap
@@ -62,6 +62,11 @@ Array [
           className="icon icon-generic"
           data-icon="?"
           data-tip="Guest characters that tag along for the adventures in this episodes"
+          style={
+            Object {
+              "color": "lightgrey",
+            }
+          }
         />
       </sup>
     </h4>
@@ -161,6 +166,11 @@ Array [
           className="icon icon-generic"
           data-icon="?"
           data-tip="Planets where events in this episode take place"
+          style={
+            Object {
+              "color": "lightgrey",
+            }
+          }
         />
       </sup>
     </h4>

--- a/__test__/__snapshots__/FilterSidebar.test.js.snap
+++ b/__test__/__snapshots__/FilterSidebar.test.js.snap
@@ -56,22 +56,14 @@ Array [
   >
     <h4>
       Guest character
-      <span>
-        <sup
-          aria-haspopup="true"
-          className="has-tip tip-right"
-          data-tooltip={true}
-          style={
-            Object {
-              "background": "white",
-              "border": "none",
-            }
-          }
-          title="Guest characters that tag along for the adventures in this episodes"
-        >
-          ?
-        </sup>
-      </span>
+      <sup>
+         
+        <span
+          className="icon icon-generic"
+          data-icon="?"
+          data-tip="Guest characters that tag along for the adventures in this episodes"
+        />
+      </sup>
     </h4>
     <div
       className="css-10nd86i"
@@ -163,22 +155,14 @@ Array [
   >
     <h4>
       Planet
-      <span>
-        <sup
-          aria-haspopup="true"
-          className="has-tip tip-right"
-          data-tooltip={true}
-          style={
-            Object {
-              "background": "white",
-              "border": "none",
-            }
-          }
-          title="Planets where events in this episode take place"
-        >
-          ?
-        </sup>
-      </span>
+      <sup>
+         
+        <span
+          className="icon icon-generic"
+          data-icon="?"
+          data-tip="Planets where events in this episode take place"
+        />
+      </sup>
     </h4>
     <div
       className="css-10nd86i"

--- a/__test__/__snapshots__/FilterSidebar.test.js.snap
+++ b/__test__/__snapshots__/FilterSidebar.test.js.snap
@@ -60,8 +60,9 @@ Array [
          
         <span
           className="icon icon-generic"
+          data-html={true}
           data-icon="i"
-          data-tip="Guest characters that tag along for the<br>adventures in this episodes"
+          data-tip="<span>Guest characters that tag along for the<br>adventures in this episodes</span>"
           style={
             Object {
               "color": "lightgrey",
@@ -165,8 +166,9 @@ Array [
          
         <span
           className="icon icon-generic"
+          data-html={true}
           data-icon="i"
-          data-tip="Planets where events in this episode take<br>place"
+          data-tip="<span>Planets where events in this episode take<br>place</span>"
           style={
             Object {
               "color": "lightgrey",

--- a/__test__/__snapshots__/FilterSidebar.test.js.snap
+++ b/__test__/__snapshots__/FilterSidebar.test.js.snap
@@ -60,11 +60,12 @@ Array [
          
         <span
           className="icon icon-generic"
-          data-icon="?"
-          data-tip="Guest characters that tag along for the adventures in this episodes"
+          data-icon="i"
+          data-tip="Guest characters that tag along for the<br>adventures in this episodes"
           style={
             Object {
               "color": "lightgrey",
+              "fontSize": "smaller",
             }
           }
         />
@@ -164,11 +165,12 @@ Array [
          
         <span
           className="icon icon-generic"
-          data-icon="?"
-          data-tip="Planets where events in this episode take place"
+          data-icon="i"
+          data-tip="Planets where events in this episode take<br>place"
           style={
             Object {
               "color": "lightgrey",
+              "fontSize": "smaller",
             }
           }
         />

--- a/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
@@ -10,11 +10,12 @@ exports[`MultiselectDropdownFacetGroup matches snapshot 1`] = `
        
       <span
         className="icon icon-generic"
-        data-icon="?"
-        data-tip="Planets where events in this episode take place"
+        data-icon="i"
+        data-tip="Planets where events in this episode take<br>place"
         style={
           Object {
             "color": "lightgrey",
+            "fontSize": "smaller",
           }
         }
       />

--- a/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
@@ -12,6 +12,11 @@ exports[`MultiselectDropdownFacetGroup matches snapshot 1`] = `
         className="icon icon-generic"
         data-icon="?"
         data-tip="Planets where events in this episode take place"
+        style={
+          Object {
+            "color": "lightgrey",
+          }
+        }
       />
     </sup>
   </h4>

--- a/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
@@ -10,8 +10,9 @@ exports[`MultiselectDropdownFacetGroup matches snapshot 1`] = `
        
       <span
         className="icon icon-generic"
+        data-html={true}
         data-icon="i"
-        data-tip="Planets where events in this episode take<br>place"
+        data-tip="<span>Planets where events in this episode take<br>place</span>"
         style={
           Object {
             "color": "lightgrey",

--- a/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
+++ b/__test__/__snapshots__/MultiselectDropdownFacetGroup.test.js.snap
@@ -6,22 +6,14 @@ exports[`MultiselectDropdownFacetGroup matches snapshot 1`] = `
 >
   <h4>
     Planet
-    <span>
-      <sup
-        aria-haspopup="true"
-        className="has-tip tip-right"
-        data-tooltip={true}
-        style={
-          Object {
-            "background": "white",
-            "border": "none",
-          }
-        }
-        title="Planets where events in this episode take place"
-      >
-        ?
-      </sup>
-    </span>
+    <sup>
+       
+      <span
+        className="icon icon-generic"
+        data-icon="?"
+        data-tip="Planets where events in this episode take place"
+      />
+    </sup>
   </h4>
   <div
     className="css-10nd86i"

--- a/__test__/__snapshots__/TooltipIcon.test.js.snap
+++ b/__test__/__snapshots__/TooltipIcon.test.js.snap
@@ -1,0 +1,18 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TooltipIcon matches snapshot 1`] = `
+<sup>
+   
+  <span
+    className="icon icon-generic"
+    data-icon="i"
+    data-tip="The blowfish puffs himself up four, five<br>times larger than normal and why? Why does<br>he do that? So that it makes him intimidating,<br>that's why. Intimidating! So that the other,<br>scarier fish are scared off. And that's you!<br>You are a blowfish. You see it's just all<br>an illusion. You see it's... it's nothing<br>but air. Now... who messes with the blowfish,<br>Jesse? You're damn right. You are a blowfish.<br>Say it again. Say it like you mean it. You're<br>a BLOWFISH!"
+    style={
+      Object {
+        "color": "lightgrey",
+        "fontSize": "smaller",
+      }
+    }
+  />
+</sup>
+`;

--- a/__test__/__snapshots__/TooltipIcon.test.js.snap
+++ b/__test__/__snapshots__/TooltipIcon.test.js.snap
@@ -5,8 +5,9 @@ exports[`TooltipIcon matches snapshot 1`] = `
    
   <span
     className="icon icon-generic"
+    data-html={true}
     data-icon="i"
-    data-tip="The blowfish puffs himself up four, five<br>times larger than normal and why? Why does<br>he do that? So that it makes him intimidating,<br>that's why. Intimidating! So that the other,<br>scarier fish are scared off. And that's you!<br>You are a blowfish. You see it's just all<br>an illusion. You see it's... it's nothing<br>but air. Now... who messes with the blowfish,<br>Jesse? You're damn right. You are a blowfish.<br>Say it again. Say it like you mean it. You're<br>a BLOWFISH!"
+    data-tip="<span>The blowfish puffs himself up four, five<br>times larger than normal and why? Why does<br>he do that? So that it makes him intimidating,<br>that's why. Intimidating! So that the other,<br>scarier fish are scared off. And that's you!<br>You are a blowfish. You see it's just all<br>an illusion. You see it's... it's nothing<br>but air. Now... who messes with the blowfish,<br>Jesse? You're damn right. You are a blowfish.<br>Say it again. Say it like you mean it. You're<br>a BLOWFISH!</span>"
     style={
       Object {
         "color": "lightgrey",

--- a/html/facetedSearchContainerDemo.js
+++ b/html/facetedSearchContainerDemo.js
@@ -21,13 +21,13 @@
             group: `Guest character`,
             value: `gwendolyn`,
             label: `Gwendolyn`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Guest character`,
             value: `ma-sha`,
             label: `Ma-Sha`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Season`,
@@ -52,13 +52,13 @@
             group: `Guest character`,
             value: `birdperson`,
             label: `Birdperson`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Guest character`,
             value: `squanchy`,
             label: `Squanchy`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Season`,
@@ -77,7 +77,7 @@
             group: `Guest character`,
             value: `birdperson`,
             label: `Birdperson`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Planet`,
@@ -102,13 +102,13 @@
             group: `Guest character`,
             value: `squanchy`,
             label: `Squanchy`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Guest character`,
             value: `abradolf_lincler`,
             label: `Abradolf Lincler`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Season`,
@@ -127,13 +127,13 @@
             group: `Guest character`,
             value: `ricktiminus_sancheziminius`,
             label: `Ricktiminus Sancheziminius`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Guest character`,
             value: `abradolf_lincler`,
             label: `Abradolf Lincler`,
-            description: `Guest character Tooltip`
+            description: `The “Guest character” tooltip is very long so we can make sure that the tooltip text is conveniently broken into several lines to improve readability and it doesn’t overflow or cover elements in the view that we might want to read at the same time that the tooltip is being shown`
           },
           {
             group: `Planet`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc3",
+  "version": "2.4.0-rc4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc1",
+  "version": "2.4.0-rc2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-beta",
+  "version": "2.4.0-rc1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc2",
+  "version": "2.4.0-rc3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.3.0",
+  "version": "2.4.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1218,7 +1218,7 @@
     },
     "ansi-escapes": {
       "version": "3.1.0",
-      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
       "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw==",
       "dev": true
     },
@@ -1402,7 +1402,7 @@
         },
         "util": {
           "version": "0.10.3",
-          "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
           "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
           "dev": true,
           "requires": {
@@ -2197,7 +2197,7 @@
     },
     "cacache": {
       "version": "10.0.4",
-      "resolved": "http://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-10.0.4.tgz",
       "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
       "dev": true,
       "requires": {
@@ -3119,7 +3119,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
-      "dev": true,
       "requires": {
         "domelementtype": "~1.1.1",
         "entities": "~1.1.1"
@@ -3128,8 +3127,7 @@
         "domelementtype": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
-          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
-          "dev": true
+          "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs="
         }
       }
     },
@@ -3142,8 +3140,7 @@
     "domelementtype": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.2.1.tgz",
-      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA==",
-      "dev": true
+      "integrity": "sha512-SQVCLFS2E7G5CRCMdn6K9bIhRj1bS6QBWZfF0TUPh4V/BbqrQ619IdSS3/izn0FZ+9l+uODzaZjb08fjOfablA=="
     },
     "domexception": {
       "version": "1.0.1",
@@ -3158,7 +3155,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
       "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-      "dev": true,
       "requires": {
         "domelementtype": "1"
       }
@@ -3167,7 +3163,6 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
-      "dev": true,
       "requires": {
         "dom-serializer": "0",
         "domelementtype": "1"
@@ -3274,8 +3269,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "enzyme": {
       "version": "3.7.0",
@@ -5279,7 +5273,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.0.tgz",
       "integrity": "sha512-J1nEUGv+MkXS0weHNWVKJJ+UrLfePxRWpN3C9bEi9fLxL2+ggW94DQvgYVXsaT30PGwYRIZKNZXuyMhp3Di4bQ==",
-      "dev": true,
       "requires": {
         "domelementtype": "^1.3.0",
         "domhandler": "^2.3.0",
@@ -5292,14 +5285,12 @@
         "domelementtype": {
           "version": "1.3.0",
           "resolved": "http://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
-          "dev": true
+          "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI="
         },
         "readable-stream": {
           "version": "3.0.6",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.0.6.tgz",
           "integrity": "sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==",
-          "dev": true,
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -5442,8 +5433,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "inquirer": {
       "version": "6.2.0",
@@ -8676,6 +8666,16 @@
         "scheduler": "^0.10.0"
       }
     },
+    "react-tooltip": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-3.9.0.tgz",
+      "integrity": "sha512-vpn738FVv2oe2LzdwUchped3WqLgZSQwrBow+ceChS1+lFEJBPjOa9KD3JH/L/s0Aorxawi3A20qBcHX7vqaag==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "prop-types": "^15.6.0",
+        "sanitize-html-react": "^1.13.0"
+      }
+    },
     "react-transition-group": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.5.0.tgz",
@@ -8811,6 +8811,11 @@
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
+    },
+    "regexp-quote": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
+      "integrity": "sha1-Hg9GUMhi3L/tVP1CsUjpuxch/PI="
     },
     "regexpp": {
       "version": "2.0.1",
@@ -9115,6 +9120,16 @@
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
+      }
+    },
+    "sanitize-html-react": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html-react/-/sanitize-html-react-1.13.0.tgz",
+      "integrity": "sha1-51e5rbryyKdi89Lf9wE4g44FQgo=",
+      "requires": {
+        "htmlparser2": "^3.9.0",
+        "regexp-quote": "0.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "sax": {
@@ -9759,7 +9774,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -10437,8 +10451,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -11306,8 +11319,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8533,6 +8533,12 @@
         "ret": "~0.1.10"
       }
     },
+    "random-words": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/random-words/-/random-words-1.1.0.tgz",
+      "integrity": "sha512-GyV8PlSmQE08S/RSCjG9Uh0uQaUC7iRpA18PWk9OSnvNCzKQ+B2NxqqN/cYBej4t7dfBWxh10KFBYSiNcg1jlg==",
+      "dev": true
+    },
     "randomatic": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc2",
+  "version": "2.4.0-rc3",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-beta",
+  "version": "2.4.0-rc1",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "fetch-mock": "^7.2.2",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^23.6.0",
+    "random-words": "^1.1.0",
     "react-test-renderer": "^16.6.0",
     "webpack": "^4.23.1",
     "webpack-cli": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc3",
+  "version": "2.4.0-rc4",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.4.0-rc1",
+  "version": "2.4.0-rc2",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-faceted-search",
-  "version": "2.3.0",
+  "version": "2.4.0-beta",
   "description": "Faceted experiments list for Single Cell Expression Atlas gene search results",
   "main": "lib/index.js",
   "scripts": {
@@ -38,6 +38,7 @@
     "react": "^16.6.0",
     "react-dom": "^16.6.0",
     "react-select": "^2.1.1",
+    "react-tooltip": "^3.9.0",
     "styled-components": "^4.0.3",
     "urijs": "^1.19.1"
   },

--- a/src/FacetedSearchContainer.js
+++ b/src/FacetedSearchContainer.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import ReactTooltip from 'react-tooltip'
 import PropTypes from 'prop-types'
 import _ from 'lodash'
 
@@ -129,6 +130,7 @@ class FacetedSearchContainer extends React.Component {
           <FilterList {...{resultsMessage, ResultElementClass}}
                       filteredResults={this._filterResults(selectedFacets)}/>
         </div>
+        <ReactTooltip effect={`solid`}/>
       </div>
     )
   }

--- a/src/FacetedSearchContainer.js
+++ b/src/FacetedSearchContainer.js
@@ -130,7 +130,7 @@ class FacetedSearchContainer extends React.Component {
           <FilterList {...{resultsMessage, ResultElementClass}}
                       filteredResults={this._filterResults(selectedFacets)}/>
         </div>
-        <ReactTooltip effect={`solid`}/>
+        <ReactTooltip effect={`solid`} multiline={`true`}/>
       </div>
     )
   }

--- a/src/FacetedSearchContainer.js
+++ b/src/FacetedSearchContainer.js
@@ -130,7 +130,7 @@ class FacetedSearchContainer extends React.Component {
           <FilterList {...{resultsMessage, ResultElementClass}}
                       filteredResults={this._filterResults(selectedFacets)}/>
         </div>
-        <ReactTooltip effect={`solid`} multiline={`true`}/>
+        <ReactTooltip effect={`solid`}/>
       </div>
     )
   }

--- a/src/facetgroups/CheckboxFacetGroup.js
+++ b/src/facetgroups/CheckboxFacetGroup.js
@@ -10,10 +10,6 @@ const CheckboxOption = ({group, value, label, disabled, checked, onChange}) =>
   <label style={disabled ? {color: `lightgrey`} : {}}>{label}</label>
 </div>
 
-const tooltipStyle = {
-  background: `white`,
-  border: `none`
-}
 // In principle we don’t need this component to be stateful, but in doing so we can create a custom _handleChange
 // function that will ultimately call onChange(facetGroupName, facets); this allows us to have the same API as
 // React-Select and reuse the same callback for both checkbox-style and multiselect facet groups
@@ -39,11 +35,12 @@ class CheckboxFacetGroup extends React.Component {
 
     return (
       <div className={`padding-bottom-xlarge`}>
-        <h4>{facetGroupName}
-          {facetGroupNameDescription &&
-          <span>
-            <sup data-tooltip aria-haspopup="true" className={`has-tip tip-right`} style={tooltipStyle} title={facetGroupNameDescription}>?</sup>
-          </span>}
+        <h4>
+          {facetGroupName}
+          {
+            facetGroupNameDescription &&
+            <sup> <span  data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`}/></sup>
+          }
         </h4>
       {facets.map((facet) =>
         <CheckboxOption {...facet}

--- a/src/facetgroups/CheckboxFacetGroup.js
+++ b/src/facetgroups/CheckboxFacetGroup.js
@@ -39,7 +39,7 @@ class CheckboxFacetGroup extends React.Component {
           {facetGroupName}
           {
             facetGroupNameDescription &&
-            <sup> <span  data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`}/></sup>
+            <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`} style={{color:`lightgrey`}}/></sup>
           }
         </h4>
       {facets.map((facet) =>

--- a/src/facetgroups/CheckboxFacetGroup.js
+++ b/src/facetgroups/CheckboxFacetGroup.js
@@ -2,6 +2,7 @@ import React from 'react'
 import { xorBy as _xorBy } from 'lodash'
 
 import FacetGroupPropTypes from './FacetGroupPropTypes'
+import TooltipIcon from './TooltipIcon'
 
 const CheckboxOption = ({group, value, label, disabled, checked, onChange}) =>
 <div>
@@ -36,11 +37,8 @@ class CheckboxFacetGroup extends React.Component {
     return (
       <div className={`padding-bottom-xlarge`}>
         <h4>
-          {facetGroupName}
-          {
-            facetGroupNameDescription &&
-            <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`} style={{color:`lightgrey`}}/></sup>
-          }
+          { facetGroupName }
+          { facetGroupNameDescription && <TooltipIcon tooltipText={facetGroupNameDescription}/> }
         </h4>
       {facets.map((facet) =>
         <CheckboxOption {...facet}

--- a/src/facetgroups/MultiselectDropdownFacetGroup.js
+++ b/src/facetgroups/MultiselectDropdownFacetGroup.js
@@ -3,6 +3,7 @@ import Select from 'react-select'
 import styled from 'styled-components'
 
 import FacetGroupPropTypes from './FacetGroupPropTypes'
+import TooltipIcon from './TooltipIcon'
 
 // We replace the dropdown indicator for another component because the default chevron is a SVG element, not a
 // background-image, whereas the control can be styled using the styles API packaged in React-Select
@@ -53,11 +54,8 @@ const ebiVfSelectStyles = {
 const MultiselectDropdownFacetGroup = ({facetGroupName, facetGroupNameDescription, facets, onChange}) =>
   <div className={`padding-bottom-xlarge`}>
     <h4>
-      {facetGroupName}
-      {
-        facetGroupNameDescription &&
-        <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`} style={{color:`lightgrey`}}/></sup>
-      }
+      { facetGroupName }
+      { facetGroupNameDescription && <TooltipIcon tooltipText={facetGroupNameDescription} /> }
     </h4>
     <Select inputId={`facetGroupMultiSelectDropdown`}
             components={{ DropdownIndicator, IndicatorSeparator: null }}

--- a/src/facetgroups/MultiselectDropdownFacetGroup.js
+++ b/src/facetgroups/MultiselectDropdownFacetGroup.js
@@ -50,19 +50,15 @@ const ebiVfSelectStyles = {
   })
 }
 
-const tooltipStyle = {
-    background: `white`,
-    border: `none`
-}
-
 const MultiselectDropdownFacetGroup = ({facetGroupName, facetGroupNameDescription, facets, onChange}) =>
   <div className={`padding-bottom-xlarge`}>
-    <h4>{facetGroupName}
-    {facetGroupNameDescription &&
-      <span>
-        <sup data-tooltip aria-haspopup="true" className={`has-tip tip-right`} style={tooltipStyle} title={facetGroupNameDescription}>?</sup>
-      </span>
-    }</h4>
+    <h4>
+      {facetGroupName}
+      {
+        facetGroupNameDescription &&
+        <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`}/></sup>
+      }
+    </h4>
     <Select inputId={`facetGroupMultiSelectDropdown`}
             components={{ DropdownIndicator, IndicatorSeparator: null }}
             styles={ebiVfSelectStyles}

--- a/src/facetgroups/MultiselectDropdownFacetGroup.js
+++ b/src/facetgroups/MultiselectDropdownFacetGroup.js
@@ -56,7 +56,7 @@ const MultiselectDropdownFacetGroup = ({facetGroupName, facetGroupNameDescriptio
       {facetGroupName}
       {
         facetGroupNameDescription &&
-        <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`}/></sup>
+        <sup> <span data-tip={facetGroupNameDescription} className={`icon icon-generic`} data-icon={`?`} style={{color:`lightgrey`}}/></sup>
       }
     </h4>
     <Select inputId={`facetGroupMultiSelectDropdown`}

--- a/src/facetgroups/TooltipIcon.js
+++ b/src/facetgroups/TooltipIcon.js
@@ -1,9 +1,25 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+const splitText = str => {
+  const maxLength = 40
+
+  return str.split(` `).reduce(
+    (acc, word) => {
+      if (acc[acc.length - 1].length < maxLength) {
+        acc[acc.length - 1] = `${acc[acc.length - 1]} ${word}`
+      } else {
+        acc.push(word)
+      }
+      return acc
+    },
+    [``]
+  ).join(`<br>`).trim()
+}
+
 const TooltipIcon = ({tooltipText}) =>
   <sup> <span
-          data-tip={tooltipText}
+          data-tip={splitText(tooltipText)}
           className={`icon icon-generic`} data-icon={`i`}
           style={{color: `lightgrey`, fontSize: `smaller`}}/>
   </sup>

--- a/src/facetgroups/TooltipIcon.js
+++ b/src/facetgroups/TooltipIcon.js
@@ -1,0 +1,15 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+const TooltipIcon = ({tooltipText}) =>
+  <sup> <span
+          data-tip={tooltipText}
+          className={`icon icon-generic`} data-icon={`i`}
+          style={{color: `lightgrey`, fontSize: `smaller`}}/>
+  </sup>
+
+TooltipIcon.propTypes = {
+  tooltipText: PropTypes.string.isRequired
+}
+
+export default TooltipIcon

--- a/src/facetgroups/TooltipIcon.js
+++ b/src/facetgroups/TooltipIcon.js
@@ -19,7 +19,8 @@ const splitText = str => {
 
 const TooltipIcon = ({tooltipText}) =>
   <sup> <span
-          data-tip={splitText(tooltipText)}
+          data-tip={`<span>${splitText(tooltipText)}</span>`}
+          data-html={true}
           className={`icon icon-generic`} data-icon={`i`}
           style={{color: `lightgrey`, fontSize: `smaller`}}/>
   </sup>


### PR DESCRIPTION
Calling `$(document).foundation();` in `componentDidUpdate` is not the best thing since introduces dependencies on jQuery and Foundation which are not part of the project (it’s already enough using Foundation classes). Doing that outputs warning messages to the console and, all in all, Foundation is not very apt at handling a dynamic DOM, so let’s use our “own” tooltips.